### PR TITLE
adapt to non-smx survey and non-existent vars (slaegt & kynfaeri)

### DIFF
--- a/R/tables.R
+++ b/R/tables.R
@@ -214,10 +214,10 @@ hv_measures <- function(pth, std = TRUE, trim = TRUE) {
                   kyn,
                   kynthroski,
                   oslaegt,
-                  slaegt,
+#                  slaegt,
                   magaastand,
                   lifur,
-                  kynfaeri,
+#                  kynfaeri,
                   kvarnanr,
                   dplyr::everything())
                  

--- a/man/hv_read_zip_data.Rd
+++ b/man/hv_read_zip_data.Rd
@@ -4,7 +4,7 @@
 \alias{hv_read_zip_data}
 \title{Reads muliple hafvogs files}
 \usage{
-hv_read_zip_data(zip_file)
+hv_read_zip_data(zip_file, smx = FALSE)
 }
 \arguments{
 \item{zip_file}{File name, including path}

--- a/man/hv_read_zip_file.Rd
+++ b/man/hv_read_zip_file.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/get_zip_data.R
 \name{hv_read_zip_file}
 \alias{hv_read_zip_file}
-\title{Reads a sinle hafvog zip file}
+\title{Reads a single hafvog zip file}
 \usage{
-hv_read_zip_file(zip_file)
+hv_read_zip_file(zip_file, smx = FALSE)
 }
 \arguments{
 \item{zip_file}{File name, including path}
@@ -13,5 +13,5 @@ hv_read_zip_file(zip_file)
 a list
 }
 \description{
-Reads a sinle hafvog zip file
+Reads a single hafvog zip file
 }


### PR DESCRIPTION
quick fix for non-smx survey (use synis_id instead of index created from rect and tow-id. Also dropping naming variables that contain params not collected on non-smx survey (gutted weight, gonad weight). This set will vary between surveys, so perhaps this could be taken further by not naming more than the minumum of columns, ...